### PR TITLE
docs: add footnote example

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -236,7 +236,7 @@ def md_to_html(md_text):
     ]
     html_text = markdown2.markdown(
         md_text,
-        extras=['fenced-code-blocks', 'link-patterns'],
+        extras=['fenced-code-blocks', 'link-patterns', 'footnotes'],
         link_patterns=link_patterns,
     )
     return html_text

--- a/md.md
+++ b/md.md
@@ -115,6 +115,12 @@ for readability.
 
 Markdown has no specialized syntax for notes.
 
+### Footnotes
+
+Extended version of markdown does support footnotes[^1].
+
+[^1]: The footnote will mostly be displayed in the bottom no matter where you define it, hence _the name_.
+
 ### Warnings
 
 Markdown has no specialized syntax for warnings.

--- a/mdrst.rst
+++ b/mdrst.rst
@@ -365,6 +365,23 @@ Notes etc
 
           GitHub's RST rendering doesn't make this stand out much.
 
+   * - Footnotes
+     - ::
+
+          Extended version of markdown does support footnotes[^1].
+
+          [^1]: The footnote will mostly be displayed in the bottom no matter where you define it, hence _the name_.
+
+     - ::
+
+          An example of footnote [1]_.
+
+          .. [1] It's similar to hyperlink syntax.
+
+     -
+
+
+
    * - Warnings
      - ::
 

--- a/rst.rst
+++ b/rst.rst
@@ -152,6 +152,13 @@ Notes
 
 .. note: GitHub's RST rendering doesn't make this stand out much.
 
+Footnotes
+=========
+
+An example of footnote [1]_.
+
+.. [1] It's similar to hyperlink syntax.
+
 Warnings
 ========
 


### PR DESCRIPTION
-   Adding examples for both rst[^1] and markdown[^2] footnote.
 
- Add footnoes extra for markdown2 parse function. 

- It was tested by viewing [md/rst].html files after running `python convert.py`

 [^1]: https://docutils.sourceforge.io/docs/user/rst/quickref.html#footnotes
 [^2]: https://www.markdownguide.org/extended-syntax/#footnotes